### PR TITLE
Snowline correction

### DIFF
--- a/src/pnml/alley_houses.pnml
+++ b/src/pnml/alley_houses.pnml
@@ -133,7 +133,7 @@ item (FEAT_HOUSES, item_alley_houses, 27, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 1919];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				4;
         animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/apartment_block_1.pnml
+++ b/src/pnml/apartment_block_1.pnml
@@ -332,7 +332,7 @@ item (FEAT_HOUSES, item_apartment_block_1, 77, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1850, 1919];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/apartment_building.pnml
+++ b/src/pnml/apartment_building.pnml
@@ -96,7 +96,7 @@ item (FEAT_HOUSES, item_apartment_building_t, 37, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -119,7 +119,7 @@ item (FEAT_HOUSES, item_apartment_building_c, 59, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB,), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB,), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/apartments_shops.pnml
+++ b/src/pnml/apartments_shops.pnml
@@ -1621,7 +1621,7 @@ item (FEAT_HOUSES, item_apartments_shops, 80, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/cathedral.pnml
+++ b/src/pnml/cathedral.pnml
@@ -165,7 +165,7 @@ item (FEAT_HOUSES, item_cathedral, 63, HOUSE_SIZE_2X2) {
 		probability:				7;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			50;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	200;
 		building_class:				3;
         building_flags:             bitmask(HOUSE_FLAG_PROTECTED);

--- a/src/pnml/church.pnml
+++ b/src/pnml/church.pnml
@@ -173,7 +173,7 @@ item (FEAT_HOUSES, item_church_v, 4, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			50;
-		availability_mask:			[ALL_TOWNZONES, ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES, ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				2;
 		building_flags:				bitmask(HOUSE_FLAG_CHURCH, HOUSE_FLAG_PROTECTED);
@@ -198,7 +198,7 @@ item (FEAT_HOUSES, item_church_t_c, 44, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[ALL_TOWNZONES, ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES, ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				4;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/cinema.pnml
+++ b/src/pnml/cinema.pnml
@@ -102,7 +102,7 @@ item (FEAT_HOUSES, item_cinema, 43, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[2010, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	140;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/city_hall.pnml
+++ b/src/pnml/city_hall.pnml
@@ -251,7 +251,7 @@ item (FEAT_HOUSES, item_city_hall, 67, HOUSE_SIZE_2X2) {
 		probability:				7;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			50;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	220;
 		building_class:				3;
         building_flags:             bitmask(HOUSE_FLAG_PROTECTED);

--- a/src/pnml/city_park.pnml
+++ b/src/pnml/city_park.pnml
@@ -357,7 +357,7 @@ item (FEAT_HOUSES, item_city_park, 62, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1850, 9999];
 		minimum_lifetime:			50;
-		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	40;
 		building_class:				3;
         building_flags:             bitmask(HOUSE_FLAG_PROTECTED);

--- a/src/pnml/department_store.pnml
+++ b/src/pnml/department_store.pnml
@@ -220,7 +220,7 @@ item (FEAT_HOUSES, item_department_store, 81, HOUSE_SIZE_1X2) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	180;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/farm.pnml
+++ b/src/pnml/farm.pnml
@@ -97,7 +97,7 @@ item (FEAT_HOUSES, item_farm, 23, HOUSE_SIZE_2X2) {
 		probability:				1;
 		years_available:			[1920, 2009];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_EDGE, TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_EDGE, TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/farm_estate.pnml
+++ b/src/pnml/farm_estate.pnml
@@ -165,7 +165,7 @@ item (FEAT_HOUSES, item_farm_estate, 6, HOUSE_SIZE_2X2) {
 		probability:				1;
 		years_available:			[1700, 1919];
 		minimum_lifetime:			20;
-		availability_mask:			[ALL_TOWNZONES, ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES, ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/farm_house.pnml
+++ b/src/pnml/farm_house.pnml
@@ -302,7 +302,7 @@ item (FEAT_HOUSES, item_farm_house, 1, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 1979];
 		minimum_lifetime:			5;
-		availability_mask:			[bitmask(TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	75;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/grand_hotel.pnml
+++ b/src/pnml/grand_hotel.pnml
@@ -125,7 +125,7 @@ item (FEAT_HOUSES, item_grand_hotel, 71, HOUSE_SIZE_1X2) {
 		probability:				7;
 		years_available:			[1850, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	180;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/guest_house.pnml
+++ b/src/pnml/guest_house.pnml
@@ -125,7 +125,7 @@ item (FEAT_HOUSES, item_guest_house_v, 83, HOUSE_SIZE_1X1) {
 		probability:				1;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -148,7 +148,7 @@ item (FEAT_HOUSES, item_guest_house_t_c, 84, HOUSE_SIZE_1X1) {
 		probability:				1;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/high_school.pnml
+++ b/src/pnml/high_school.pnml
@@ -123,7 +123,7 @@ item (FEAT_HOUSES, item_high_school, 40, HOUSE_SIZE_2X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_EDGE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_EDGE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	160;
 		building_class:				1;
         building_flags:             bitmask(HOUSE_FLAG_PROTECTED);

--- a/src/pnml/hospital.pnml
+++ b/src/pnml/hospital.pnml
@@ -260,7 +260,7 @@ item (FEAT_HOUSES, item_hospital, 52, HOUSE_SIZE_2X2) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			50;
-		availability_mask:			[ALL_TOWNZONES, ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES, ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	210;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/hotel.pnml
+++ b/src/pnml/hotel.pnml
@@ -134,7 +134,7 @@ item (FEAT_HOUSES, item_hotel, 85, HOUSE_SIZE_1X1) {
 		probability:				3;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	100;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/house.pnml
+++ b/src/pnml/house.pnml
@@ -103,7 +103,7 @@ item (FEAT_HOUSES, item_house_v, 21, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1950, 9999];
 		minimum_lifetime:			5;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	75;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -126,7 +126,7 @@ item (FEAT_HOUSES, item_house_t_c, 28, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1850, 9999];
 		minimum_lifetime:			5;
-		availability_mask:			[bitmask(TOWNZONE_EDGE, TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_EDGE, TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	75;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/large_office_building.pnml
+++ b/src/pnml/large_office_building.pnml
@@ -123,7 +123,7 @@ item (FEAT_HOUSES, item_large_office_building, 87, HOUSE_SIZE_2X1) {
 		probability:				7;
 		years_available:			[1980, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	180;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/mansion.pnml
+++ b/src/pnml/mansion.pnml
@@ -92,7 +92,7 @@ item (FEAT_HOUSES, item_mansion, 36, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	100;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/merchant_house.pnml
+++ b/src/pnml/merchant_house.pnml
@@ -2266,7 +2266,7 @@ item (FEAT_HOUSES, item_merchant_house, 33, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 1919];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				4;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/multi_family_home.pnml
+++ b/src/pnml/multi_family_home.pnml
@@ -100,7 +100,7 @@ item (FEAT_HOUSES, item_multi_family_home_v, 38, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1950, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -123,7 +123,7 @@ item (FEAT_HOUSES, item_multi_family_home_t, 39, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1950, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -146,7 +146,7 @@ item (FEAT_HOUSES, item_multi_family_home_c, 60, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1950, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_EDGE, TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_EDGE, TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/office_building.pnml
+++ b/src/pnml/office_building.pnml
@@ -102,7 +102,7 @@ item (FEAT_HOUSES, item_office_building, 86, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1950, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	140;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/old_house.pnml
+++ b/src/pnml/old_house.pnml
@@ -92,7 +92,7 @@ item (FEAT_HOUSES, item_old_house, 19, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1850, 1979];
 		minimum_lifetime:			5;
-		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	75;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/old_town_house.pnml
+++ b/src/pnml/old_town_house.pnml
@@ -96,7 +96,7 @@ item (FEAT_HOUSES, item_old_town_house_t, 31, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 1919];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	80;
 		building_class:				4;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -120,7 +120,7 @@ item (FEAT_HOUSES, item_old_town_house_c, 56, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 1919];
 		minimum_lifetime:			10;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	80;
 		building_class:				4;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/old_town_houses.pnml
+++ b/src/pnml/old_town_houses.pnml
@@ -105,7 +105,7 @@ item (FEAT_HOUSES, item_old_town_houses, 2, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 1919];
 		minimum_lifetime:			10;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	80;
 		building_class:				4;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/school.pnml
+++ b/src/pnml/school.pnml
@@ -215,7 +215,7 @@ item (FEAT_HOUSES, item_school_v, 18, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
         building_flags:             bitmask(HOUSE_FLAG_PROTECTED);
@@ -239,7 +239,7 @@ item (FEAT_HOUSES, item_school_t_c, 45, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_OUTSKIRT, TOWNZONE_OUTER_SUBURB, TOWNZONE_INNER_SUBURB), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/shop.pnml
+++ b/src/pnml/shop.pnml
@@ -96,7 +96,7 @@ item (FEAT_HOUSES, item_shop_v, 22, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1950, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -119,7 +119,7 @@ item (FEAT_HOUSES, item_shop_t_c, 47, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1950, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/shopping_mall.pnml
+++ b/src/pnml/shopping_mall.pnml
@@ -165,7 +165,7 @@ item (FEAT_HOUSES, item_shopping_mall, 73, HOUSE_SIZE_2X2) {
 		probability:				7;
 		years_available:			[2010, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[ALL_TOWNZONES, ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES, ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	200;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/shops.pnml
+++ b/src/pnml/shops.pnml
@@ -92,7 +92,7 @@ item (FEAT_HOUSES, item_shops_t, 34, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -115,7 +115,7 @@ item (FEAT_HOUSES, item_shops_c, 57, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/shops_offices_1.pnml
+++ b/src/pnml/shops_offices_1.pnml
@@ -332,7 +332,7 @@ item (FEAT_HOUSES, item_shops_offices_1, 3, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1850, 1919];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/shops_offices_2.pnml
+++ b/src/pnml/shops_offices_2.pnml
@@ -96,7 +96,7 @@ item (FEAT_HOUSES, item_shops_offices_2_t, 35, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	140;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -119,7 +119,7 @@ item (FEAT_HOUSES, item_shops_offices_2_c, 58, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	140;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/shops_offices_3.pnml
+++ b/src/pnml/shops_offices_3.pnml
@@ -487,7 +487,7 @@ item (FEAT_HOUSES, item_shops_offices_3, 61, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/small_farm.pnml
+++ b/src/pnml/small_farm.pnml
@@ -69,7 +69,7 @@ item (FEAT_HOUSES, item_small_farm_nw, 10, HOUSE_SIZE_2X1) {
 		probability:				7;
 		years_available:			[1700, 1949];
 		minimum_lifetime:			5;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	75;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -93,7 +93,7 @@ item (FEAT_HOUSES, item_small_farm_ne, 12, HOUSE_SIZE_1X2) {
 		probability:				7;
 		years_available:			[1700, 1949];
 		minimum_lifetime:			5;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	75;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -117,7 +117,7 @@ item (FEAT_HOUSES, item_small_farm_wn, 14, HOUSE_SIZE_2X1) {
 		probability:				7;
 		years_available:			[1700, 1949];
 		minimum_lifetime:			5;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	75;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -141,7 +141,7 @@ item (FEAT_HOUSES, item_small_farm_en, 16, HOUSE_SIZE_1X2) {
 		probability:				7;
 		years_available:			[1700, 1949];
 		minimum_lifetime:			5;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	75;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/stadium.pnml
+++ b/src/pnml/stadium.pnml
@@ -244,7 +244,7 @@ item (FEAT_HOUSES, item_stadium, 48, HOUSE_SIZE_2X2) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			50;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	200;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/tall_office_building.pnml
+++ b/src/pnml/tall_office_building.pnml
@@ -102,7 +102,7 @@ item (FEAT_HOUSES, item_tall_office_building, 89, HOUSE_SIZE_1X1) {
 		probability:				1;
 		years_available:			[1980, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	170;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/theatre.pnml
+++ b/src/pnml/theatre.pnml
@@ -102,7 +102,7 @@ item (FEAT_HOUSES, item_theatre, 42, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1920, 9999];
 		minimum_lifetime:			20;
-		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_INNER_SUBURB, TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	130;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/town_church_1.pnml
+++ b/src/pnml/town_church_1.pnml
@@ -123,7 +123,7 @@ item (FEAT_HOUSES, item_town_church_1, 29, HOUSE_SIZE_2X1) {
 		probability:				7;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			50;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	140;
 		building_class:				2;
         building_flags:             bitmask(HOUSE_FLAG_PROTECTED);

--- a/src/pnml/town_church_2.pnml
+++ b/src/pnml/town_church_2.pnml
@@ -172,7 +172,7 @@ item (FEAT_HOUSES, item_town_church_2, 78, HOUSE_SIZE_1X2) {
 		probability:				7;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			50;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	140;
 		building_class:				2;
         building_flags:             bitmask(HOUSE_FLAG_PROTECTED);

--- a/src/pnml/town_hall.pnml
+++ b/src/pnml/town_hall.pnml
@@ -106,7 +106,7 @@ item (FEAT_HOUSES, item_town_hall, 5, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 9999];
 		minimum_lifetime:			50;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	110;
 		building_class:				2;
         building_flags:             bitmask(HOUSE_FLAG_PROTECTED);

--- a/src/pnml/trading_house.pnml
+++ b/src/pnml/trading_house.pnml
@@ -102,7 +102,7 @@ item (FEAT_HOUSES, item_trading_house, 19, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 1919];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	120;
 		building_class:				4;
         animation_info:				[ANIMATION_NON_LOOPING, 1];

--- a/src/pnml/workshop.pnml
+++ b/src/pnml/workshop.pnml
@@ -156,7 +156,7 @@ item (FEAT_HOUSES, item_workshop_v, 20, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 1979];
 		minimum_lifetime:			10;
-		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];
@@ -179,7 +179,7 @@ item (FEAT_HOUSES, item_workshop_t_c, 46, HOUSE_SIZE_1X1) {
 		probability:				7;
 		years_available:			[1700, 1979];
 		minimum_lifetime:			10;
-		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES];
+		availability_mask:			[ALL_TOWNZONES & ~bitmask(TOWNZONE_CENTRE), ALL_CLIMATES | bitmask(CLIMATE_ARCTIC, ABOVE_SNOWLINE)];
 		removal_cost_multiplier:	90;
 		building_class:				1;
 		animation_info:				[ANIMATION_NON_LOOPING, 1];


### PR DESCRIPTION
Fixed an issue where houses failed to spawn above the snow line, making the NewGRF unusable in Alpine climates. This update enables building generation above the snow line.